### PR TITLE
ENH: Add --unbuffered flag that turns off buffering of output

### DIFF
--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -43,6 +43,10 @@ $columns = 80 unless $columns;
 
 GetOptions(
     "help" => \&print_usage_and_exit,
+    "unbuffered" => sub {
+        use IO::Handle qw();
+        STDOUT->autoflush(1);
+    },
     "columns=i" => \$columns,
 ) or die "unable to parse options, stopped";
 
@@ -106,7 +110,7 @@ sub char_to_columns {
 
 sub print_usage_and_exit {
     print <<EOT;
-Usage: $0 [--columns=N] [FILE]...
+Usage: $0 [--unbuffered] [--columns=N] [FILE]...
 
 Takes data on standard input or in any specified files and dumps it to
 standard output similar to cat or cut.  However, all output will be


### PR DESCRIPTION
So that the command can be used in a (Bash) `coproc`; without turning off buffering, no output is received on sending it single lines, and the `read` hangs.

Note: This doesn't add tests, as the difference is hard to observe, and the change is rather trivial.
