### PR TITLE
Add --wrap and --indent-string arguments

### DIFF
--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -29,6 +29,7 @@ use Text::CharWidth::PurePerl qw(mbwidth);
 use open ':locale';
 
 my $TABSTOP = 8;
+my $ESCAPE_SEQUENCE_PATTERN = qr/(\e\[\d*(;\d+)*m)/;
 
 my $columns = `tput cols`;
 chomp($columns);
@@ -80,7 +81,7 @@ while (my $line = <>) {
         }
         elsif ($c eq "\e") {
             # handle escape sequences
-            substr($line, $i, length($line) - $i) =~ m/(\e\[\d*(;\d+)*m)/;
+            substr($line, $i, length($line) - $i) =~ m/$ESCAPE_SEQUENCE_PATTERN/;
             die "\$` should be empty, stopped" if $`;
             my $esc_seq = $1;
             # skip over the sequence

--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -53,7 +53,8 @@ GetOptions(
         use List::Util qw(sum0);
         use Encode qw(decode_utf8);
         $indentString = decode_utf8($_[1], 1);
-        $indentLength = sum0 map { $_ eq "\t" ? $TABSTOP : char_to_columns($_) } split //, $indentString;
+        (my $indentStringWithoutEscapeSequences = $indentString) =~ s/$ESCAPE_SEQUENCE_PATTERN//g;
+        $indentLength = sum0 map { $_ eq "\t" ? $TABSTOP : char_to_columns($_) } split //, $indentStringWithoutEscapeSequences;
     },
 ) or die "unable to parse options, stopped";
 

--- a/tests/tcindent-ansi.expected
+++ b/tests/tcindent-ansi.expected
@@ -1,0 +1,9 @@
+ThisIsAVer
+[01;41m|[0myLongText
+ThatShould
+[01;41m|[0mBeBrokenI
+[01;41m|[0mntoMultip
+[01;41m|[0mleLinesAn
+[01;41m|[0mdWrappedA
+[01;41m|[0mccordingl
+[01;41m|[0my.

--- a/tests/tcindent-ansi.in
+++ b/tests/tcindent-ansi.in
@@ -1,0 +1,2 @@
+ThisIsAVeryLongText
+ThatShouldBeBrokenIntoMultipleLinesAndWrappedAccordingly.

--- a/tests/tcindent-plain.expected
+++ b/tests/tcindent-plain.expected
@@ -1,0 +1,10 @@
+ThisIsAVer
+> yLongTex
+> t
+ThatShould
+> BeBroken
+> IntoMult
+> ipleLine
+> sAndWrap
+> pedAccor
+> dingly.

--- a/tests/tcindent-plain.in
+++ b/tests/tcindent-plain.in
@@ -1,0 +1,2 @@
+ThisIsAVeryLongText
+ThatShouldBeBrokenIntoMultipleLinesAndWrappedAccordingly.

--- a/tests/tcindent-tab.expected
+++ b/tests/tcindent-tab.expected
@@ -1,0 +1,7 @@
+ThisIsAVeryLongTex
+	t
+ThatShouldBeBroken
+	IntoMultip
+	leLinesAnd
+	WrappedAcc
+	ordingly.

--- a/tests/tcindent-tab.in
+++ b/tests/tcindent-tab.in
@@ -1,0 +1,2 @@
+ThisIsAVeryLongText
+ThatShouldBeBrokenIntoMultipleLinesAndWrappedAccordingly.

--- a/tests/tcindent-unicode.expected
+++ b/tests/tcindent-unicode.expected
@@ -1,0 +1,12 @@
+ThisIsAVer
+«日»yLongT
+«日»ext
+ThatShould
+«日»BeBrok
+«日»enInto
+«日»Multip
+«日»leLine
+«日»sAndWr
+«日»appedA
+«日»ccordi
+«日»ngly.

--- a/tests/tcindent-unicode.in
+++ b/tests/tcindent-unicode.in
@@ -1,0 +1,2 @@
+ThisIsAVeryLongText
+ThatShouldBeBrokenIntoMultipleLinesAndWrappedAccordingly.

--- a/tests/tcwrap.expected
+++ b/tests/tcwrap.expected
@@ -1,0 +1,22 @@
+ThisIsAVer
+yLongText
+ThatShould
+BeBrokenIn
+toMultiple
+LinesAndWr
+appedAccor
+dingly.
+AlsoWorks
+	Wi
+th	Ta
+bCharacter
+	A
+	ny
+	
+	wh
+ere, also
+	mi
+xed with 
+日本	語
+ inside 日
+本語.

--- a/tests/tcwrap.in
+++ b/tests/tcwrap.in
@@ -1,0 +1,3 @@
+ThisIsAVeryLongText
+ThatShouldBeBrokenIntoMultipleLinesAndWrappedAccordingly.
+AlsoWorks	With	TabCharacter	A	ny		where, also	mixed with 日本	語 inside 日本語.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -50,6 +50,9 @@ do_test tc5 --columns=72
 # ==== case 6: UTF-8-demo.txt @ 40 columns
 do_test tc7 --columns=40
 
+# ==== wrap
+do_test tcwrap --wrap --columns=10
+
 if test -z "$err" ; then
     echo "PASS"
     rm -f *.out BOGUS

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -13,9 +13,9 @@ rm -f *.out BOGUS
 
 do_test() {
     prefix="$1"
-    args="$2"
+    shift
 
-$NOWRAP $args $prefix.in > $prefix.out
+$NOWRAP "$@" $prefix.in > $prefix.out
 if $DIFF $prefix.expected $prefix.out ; then
     :
 else

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -52,6 +52,10 @@ do_test tc7 --columns=40
 
 # ==== wrap
 do_test tcwrap --wrap --columns=10
+do_test tcindent-plain --wrap --indent-string '> ' --columns=10
+do_test tcindent-tab --wrap --indent-string '	' --columns=18
+do_test tcindent-ansi --wrap --indent-string '[01;41m|[0m' --columns=10
+do_test tcindent-unicode --wrap --indent-string '«日»' --columns=10
 
 if test -z "$err" ; then
     echo "PASS"


### PR DESCRIPTION
As `nowrap` already knows where to cut off a string to limit it to a certain number of screen cells, it would be nice if it also could do hard-wrapping, by inserting newline characters (and continuing with the text). I needed this for rendering text output for the [Conky](https://github.com/brndnmtthws/conky) tool, which doesn't do text wrapping like a terminal on its own, and just cuts off text.

The `--indent-string` option is a follow-up enhancement, based on [Vim's `'showbreak'` option](https://vimhelp.appspot.com/options.txt.html#%27showbreak%27), to add a visual indication (or just plain indent) that lines have been wrapped.
