### PR TITLE
FIX: Don't invoke tput if --columns is passed

### DIFF
--- a/nowrap
+++ b/nowrap
@@ -77,19 +77,10 @@ use open ':locale';
 my $TABSTOP = 8;
 my $ESCAPE_SEQUENCE_PATTERN = qr/(\e\[\d*(;\d+)*m)/;
 
-my $columns = `tput cols`;
-chomp($columns);
 my $isWrap = 0;
 my $indentString = '';
 my $indentLength = 0;
-
-if ($columns and $ENV{TERM} eq "cygwin") {
-    # use one less than the number of columns when running on Windows under
-    # cygwin.  Thanks to Ingo Karkat: https://github.com/goodell/nowrap/issues/2
-    --$columns;
-}
-
-$columns = 80 unless $columns;
+my $columns;
 
 GetOptions(
     "help" => \&print_usage_and_exit,
@@ -107,6 +98,19 @@ GetOptions(
         $indentLength = sum0 map { $_ eq "\t" ? $TABSTOP : char_to_columns($_) } split //, $indentStringWithoutEscapeSequences;
     },
 ) or die "unable to parse options, stopped";
+
+unless (defined $columns) {
+  $columns = `tput cols`;
+  chomp($columns);
+
+  if ($columns and $ENV{TERM} eq "cygwin") {
+      # use one less than the number of columns when running on Windows under
+      # cygwin.  Thanks to Ingo Karkat: https://github.com/goodell/nowrap/issues/2
+      --$columns;
+  }
+
+  $columns = 80 unless $columns;
+}
 
 if ($columns < $indentLength + 1) {
     die "--columns too small to accommodate --indent-string and any characters, stopped";

--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -31,19 +31,10 @@ use open ':locale';
 my $TABSTOP = 8;
 my $ESCAPE_SEQUENCE_PATTERN = qr/(\e\[\d*(;\d+)*m)/;
 
-my $columns = `tput cols`;
-chomp($columns);
 my $isWrap = 0;
 my $indentString = '';
 my $indentLength = 0;
-
-if ($columns and $ENV{TERM} eq "cygwin") {
-    # use one less than the number of columns when running on Windows under
-    # cygwin.  Thanks to Ingo Karkat: https://github.com/goodell/nowrap/issues/2
-    --$columns;
-}
-
-$columns = 80 unless $columns;
+my $columns;
 
 GetOptions(
     "help" => \&print_usage_and_exit,
@@ -61,6 +52,19 @@ GetOptions(
         $indentLength = sum0 map { $_ eq "\t" ? $TABSTOP : char_to_columns($_) } split //, $indentStringWithoutEscapeSequences;
     },
 ) or die "unable to parse options, stopped";
+
+unless (defined $columns) {
+  $columns = `tput cols`;
+  chomp($columns);
+
+  if ($columns and $ENV{TERM} eq "cygwin") {
+      # use one less than the number of columns when running on Windows under
+      # cygwin.  Thanks to Ingo Karkat: https://github.com/goodell/nowrap/issues/2
+      --$columns;
+  }
+
+  $columns = 80 unless $columns;
+}
 
 if ($columns < $indentLength + 1) {
     die "--columns too small to accommodate --indent-string and any characters, stopped";

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -114,3 +114,27 @@ else
     exit 1
 fi
 
+# make sure nowrap doesn't invoke 'tput' if '-c' is passed
+(
+    # TERM is the one that matters (breaks 'tput cols'), but COLUMNS and LINES
+    # are to avoid any clever fallback that might get added to nowrap in the
+    # future
+    unset TERM
+    unset COLUMMS
+    unset LINES
+
+    # send stderr to /dev/null because nohup always warns about redirecting its output
+    nohup ${NOWRAP} --columns=72 tc0.in 2>/dev/null
+    status=$?
+    if [[ $status -ne 0 ]] ; then
+        echo "ERROR: non-zero exit code ($status)"
+    fi
+
+    if $DIFF tc0.expected nohup.out ; then
+        :
+    else
+        echo "ERROR: nohup run failed (expected != output)"
+    fi
+
+    rm -f nohup.out
+)


### PR DESCRIPTION
Under certain circumstances (e.g. when run as a cron job), tput is not able to determine the columns (`tput: unknown terminal "unknown"`). For that, the columns can be explicitly set via `--columns=N`, and `nowrap` can still do its job. However, the `tput` lookup is still performed, and results in an error message (which even triggers an email for the cron job). Lookup of available terminal columns should only happen if the columns are not specified on the command-line; this also slightly improves performance.
Move the `$column` initialization to after the command-line argument parsing.