### PR TITLE
Fix/non color escape2

### DIFF
--- a/nowrap
+++ b/nowrap
@@ -75,7 +75,7 @@ use Text::CharWidth::PurePerl qw(mbwidth);
 use open ':locale';
 
 my $TABSTOP = 8;
-my $ESCAPE_SEQUENCE_PATTERN = qr/(\e\[\d*(;\d+)*m)/;
+my $ESCAPE_SEQUENCE_PATTERN = qr/(\e(\[\d*(;\d+)*m|\e*[ \t]*[^\e]))/;
 
 my $columns = `tput cols`;
 chomp($columns);
@@ -138,15 +138,20 @@ while (my $line = <>) {
             $cursor += $TABSTOP - ($cursor % $TABSTOP);
             ++$nchars;
         }
-        elsif ($c eq "\e") {
+        elsif ($c eq "\e" && substr($line, $i, length($line) - $i) =~ m/$ESCAPE_SEQUENCE_PATTERN/) {
             # handle escape sequences
-            substr($line, $i, length($line) - $i) =~ m/$ESCAPE_SEQUENCE_PATTERN/;
             die "\$` should be empty, stopped" if $`;
             my $esc_seq = $1;
             # skip over the sequence
             $i      += length($esc_seq) - 1; # -1 b/c of ++$i at loop top
             $nchars += length($esc_seq);
-            # $cursor is unchanged
+
+            my $tabCount = () = $esc_seq =~ /\t/g;
+            if ($tabCount > 0) {
+              # In contrast to spaces, tabs within the escape sequence are not
+              # swallowed.
+              $cursor += ($tabCount * $TABSTOP) - ($cursor % $TABSTOP);
+            }
 
             $append = $esc_seq;
         }

--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -92,9 +92,8 @@ while (my $line = <>) {
             $cursor += $TABSTOP - ($cursor % $TABSTOP);
             ++$nchars;
         }
-        elsif ($c eq "\e") {
+        elsif ($c eq "\e" && substr($line, $i, length($line) - $i) =~ m/$ESCAPE_SEQUENCE_PATTERN/) {
             # handle escape sequences
-            substr($line, $i, length($line) - $i) =~ m/$ESCAPE_SEQUENCE_PATTERN/;
             die "\$` should be empty, stopped" if $`;
             my $esc_seq = $1;
             # skip over the sequence

--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -29,7 +29,7 @@ use Text::CharWidth::PurePerl qw(mbwidth);
 use open ':locale';
 
 my $TABSTOP = 8;
-my $ESCAPE_SEQUENCE_PATTERN = qr/(\e(\[\d*(;\d+)*m|\e* *[^\e]))/;
+my $ESCAPE_SEQUENCE_PATTERN = qr/(\e(\[\d*(;\d+)*m|\e*[ \t]*[^\e]))/;
 
 my $columns = `tput cols`;
 chomp($columns);
@@ -99,7 +99,12 @@ while (my $line = <>) {
             # skip over the sequence
             $i      += length($esc_seq) - 1; # -1 b/c of ++$i at loop top
             $nchars += length($esc_seq);
-            # $cursor is unchanged
+
+            if ($esc_seq =~ m/\t/) {
+              # In contrast to spaces, tabs within the escape sequence are not
+              # swallowed.
+              $cursor += $TABSTOP - ($cursor % $TABSTOP);
+            }
 
             $append = $esc_seq;
         }

--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -29,7 +29,7 @@ use Text::CharWidth::PurePerl qw(mbwidth);
 use open ':locale';
 
 my $TABSTOP = 8;
-my $ESCAPE_SEQUENCE_PATTERN = qr/(\e\[\d*(;\d+)*m)/;
+my $ESCAPE_SEQUENCE_PATTERN = qr/(\e(\[\d*(;\d+)*m|\e*[^\e]))/;
 
 my $columns = `tput cols`;
 chomp($columns);

--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -100,10 +100,11 @@ while (my $line = <>) {
             $i      += length($esc_seq) - 1; # -1 b/c of ++$i at loop top
             $nchars += length($esc_seq);
 
-            if ($esc_seq =~ m/\t/) {
+            my $tabCount = () = $esc_seq =~ /\t/g;
+            if ($tabCount > 0) {
               # In contrast to spaces, tabs within the escape sequence are not
               # swallowed.
-              $cursor += $TABSTOP - ($cursor % $TABSTOP);
+              $cursor += ($tabCount * $TABSTOP) - ($cursor % $TABSTOP);
             }
 
             $append = $esc_seq;

--- a/script/nowrap.pl
+++ b/script/nowrap.pl
@@ -29,7 +29,7 @@ use Text::CharWidth::PurePerl qw(mbwidth);
 use open ':locale';
 
 my $TABSTOP = 8;
-my $ESCAPE_SEQUENCE_PATTERN = qr/(\e(\[\d*(;\d+)*m|\e*[^\e]))/;
+my $ESCAPE_SEQUENCE_PATTERN = qr/(\e(\[\d*(;\d+)*m|\e* *[^\e]))/;
 
 my $columns = `tput cols`;
 chomp($columns);

--- a/tests/tcescape.expected
+++ b/tests/tcescape.expected
@@ -7,5 +7,6 @@ adjacentesc
 after single
 after   manysp
 after	tab
+after
 endescape
 endescap

--- a/tests/tcescape.expected
+++ b/tests/tcescape.expected
@@ -1,8 +1,8 @@
 ordinary t
 this[01mbold[0mte
-singleesca
-twoescapeo
-adjacentes
-adjacentes
+singleescap
+twoescapeocc
+adjacentesc
+adjacentesc
 endescape
 endescap

--- a/tests/tcescape.expected
+++ b/tests/tcescape.expected
@@ -4,5 +4,7 @@ singleescap
 twoescapeocc
 adjacentesc
 adjacentesc
+after single
+after   manysp
 endescape
 endescap

--- a/tests/tcescape.expected
+++ b/tests/tcescape.expected
@@ -6,5 +6,6 @@ adjacentesc
 adjacentesc
 after single
 after   manysp
+after	tab
 endescape
 endescap

--- a/tests/tcescape.expected
+++ b/tests/tcescape.expected
@@ -1,0 +1,8 @@
+ordinary t
+this[01mbold[0mte
+singleesca
+twoescapeo
+adjacentes
+adjacentes
+endescape
+endescap

--- a/tests/tcescape.in
+++ b/tests/tcescape.in
@@ -7,5 +7,6 @@ adjacentescapes
 after singlespace
 after   manyspaces
 after	tabulator
+after		tabulators
 endescape
 endescap

--- a/tests/tcescape.in
+++ b/tests/tcescape.in
@@ -4,5 +4,7 @@ singleescape
 twoescapeoccurrences
 adjacentescapes
 adjacentescapes
+after singlespace
+after   manyspaces
 endescape
 endescap

--- a/tests/tcescape.in
+++ b/tests/tcescape.in
@@ -6,5 +6,6 @@ adjacentescapes
 adjacentescapes
 after singlespace
 after   manyspaces
+after	tabulator
 endescape
 endescap

--- a/tests/tcescape.in
+++ b/tests/tcescape.in
@@ -1,0 +1,8 @@
+ordinary text
+this[01mbold[0mtext
+singleescape
+twoescapeoccurrences
+adjacentescapes
+adjacentescapes
+endescape
+endescap

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -85,6 +85,9 @@ do_test tc6 --columns=72
 # ==== case 7: UTF-8-demo.txt @ 40 columns
 do_test tc7 --columns=40
 
+# ==== escape characters and colored text
+do_test tcescape --columns=10
+
 # ==== wrap
 do_test tcwrap --wrap --columns=10
 do_test tcindent-plain --wrap --indent-string '> ' --columns=10


### PR DESCRIPTION
When smashing various keys for an interactive test of `nowrap`, I managed to obtain a long `Use of uninitialized value $esc_seq` error, apparently by typing a standalone escape.

The fix to prevent the error is simple (cp. bef829e), but accounting for the correct width of non-ASCII sequence escapes led me down a rabbit hole. I can't guarantee this is entirely correct (and the behavior might differ in other terminals), but for a corner case (that I only found by accident, not real data), I think it should be better than the original behavior, is documented by an added test, and doesn't add too much additional complexity to the code.