### PR TITLE
Skip tc2 when less than required 150 columns available

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -63,7 +63,12 @@ do_test tc0 --columns=72
 do_test tc1 --columns=140
 
 # ==== case 2: simple text but don't specify columns
-do_test tc2
+required_cols=150
+if test `tput cols` -lt $required_cols ; then
+    echo "columns are "`tput cols`" not at least $required_cols, skipping test 2"
+else
+    do_test tc2
+fi
 
 # ==== case 3: colored text, don't specify columns
 assumed_cols=238


### PR DESCRIPTION
My default (unmaximized) terminal size is 80x25; I get test errors when running tc2 then.

Surround tc2 execution with a check for the required minimum terminal width, similar to what already exists for tc3, and skip the test with a message if that cannot be met.